### PR TITLE
fix(Makefile): correct go test path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build:
 	go build -o ./tmp/main ./cmd/server/main.go
 
 test:
-	go test ./..
+	go test ./...
 
 run:
 	./tmp/main


### PR DESCRIPTION
This PR fixes the test command in the Makefile

- update `go test ./..` to `go test ./...`
- Ensure all packages are properly included in test run
- Align with standard go test pattern